### PR TITLE
Increase timeout for scp in raspbian_prepare tool

### DIFF
--- a/tools/raspberry-pi2/raspbian_prepare.py
+++ b/tools/raspberry-pi2/raspbian_prepare.py
@@ -145,7 +145,7 @@ class QemuSession(object):
                                         USERNAME,
                                         HOSTNAME,
                                         dst)
-    child = pexpect.spawn(cmd)
+    child = pexpect.spawn(cmd, timeout=200)
     print 'Running: %s' % cmd
     child.expect(['password:', r"yes/no"], timeout=7)
     child.sendline(PASSWORD)


### PR DESCRIPTION
The Linux SDK bot is failing, because the scp of 90 MB to a qemu VM takes slightly more than the default 30s timeout of the pexpect module.